### PR TITLE
Remove endpoint init for web ui

### DIFF
--- a/statusmotron_ui/lib/statusmotron_ui_web/endpoint.ex
+++ b/statusmotron_ui/lib/statusmotron_ui_web/endpoint.ex
@@ -38,19 +38,4 @@ defmodule StatusmotronUIWeb.Endpoint do
     signing_salt: "7h3E7e/C"
 
   plug StatusmotronUIWeb.Router
-
-  @doc """
-  Callback invoked for dynamically configuring the endpoint.
-
-  It receives the endpoint configuration and checks if
-  configuration should be loaded from the system environment.
-  """
-  def init(_key, config) do
-    if config[:load_from_system_env] do
-      port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-      {:ok, Keyword.put(config, :http, [:inet6, port: port])}
-    else
-      {:ok, config}
-    end
-  end
 end


### PR DESCRIPTION
The init attempting to load dynamic config was causing problems in the prod environment, and I don't think it is needed in other envs, so removing it.